### PR TITLE
survive nginx reload

### DIFF
--- a/src/ngx_http_auth_radius_module.c
+++ b/src/ngx_http_auth_radius_module.c
@@ -531,6 +531,7 @@ ngx_http_auth_radius_create_main_conf( ngx_conf_t *cf )
     mconf->log = NGX_CONF_UNSET_PTR;
     mconf->radius_attempts = NGX_CONF_UNSET;
     mconf->radius_timeout = NGX_CONF_UNSET_MSEC;
+    radius_destroy_servers();
     return mconf;
 }
 

--- a/src/radius_client.c
+++ b/src/radius_client.c
@@ -153,6 +153,9 @@ void radius_destroy_servers() {
             rs->s = -1;
         }
     }
+
+    s_array_free(radius_servers, NULL);
+    radius_servers = NULL;
 }
 
 radius_req_queue_node_t*
@@ -285,7 +288,7 @@ radius_send_request( radius_req_queue_node_t* prev_req, radius_str_t* user, radi
         abort();
     }
 
-    rlog( rs, "acquire_req_queue_node: 0x%lx, r: 0x%lx", n, n->data );
+    rlog( rs, "acquire_req_queue_node: #rs: %d, 0x%lx, r: 0x%lx", radius_servers->size, n, n->data );
     
     int len = create_radius_req( rs->process_buff, sizeof( rs->process_buff ), 
         n->ident, user, passwd, &rs->secret, &rs->nas_identifier, n->auth );


### PR DESCRIPTION
We discovered that after 2 or 3 nginx reloads (SIGHUP), this module started crashing with SIGABRT.  The abort is in `ngx_http_auth_radius_module.c`, in `ngx_send_radius_request`.  `abort()` is being called because `radius_send_request()` returns NULL.

`radius_send_request()` returns NULL because `sendto()` returns errno 22, EINVAL, Invalid Argument.  `sendto()` is mad because the sockaddr passed has the value `0.0.0.0:0`, which is indeed an invalid argument.

The root cause for this is that `radius_servers` isn't cleared when nginx reloads.  New entries are added, but the old ones are kept around.  The old ones have references to the sockaddr produced by `ngx_parse_url`, but those addresses were allocated using `ngx_pcalloc`, which, as far as I understand it, allocates memory that is automatically freed (at some point; not sure when).  I suspect this memory is freed and then reallocated to someone else through another `ngx_pcalloc` call, which zeroes the memory.

Long story short: we need to empty the `radius_servers` list on config reload.  The easiest way I found to do that was to wipe the list at the time that the location configuration is generated.  I verified that before this fix, the number of entries in radius_servers would increase by the number of radius servers in the config every reload.  After, there is no longer an increase and we don't see the EINVAL/SIGABRT crashes.

This PR clears the radius_servers list in what I *think* is the right spot, and it also adds logging for the number of radius servers.